### PR TITLE
feat: replace deprecated keys and provide dynamic year

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,8 +82,6 @@ search:
 
 logo: "/assets/images/logo-mekari-developers.png"
 
-footer_content: "Copyright &copy; 2021 PT Mid Solusi Nusantara."
-
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
 last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,0 +1,1 @@
+<p class="text-small text-grey-dk-100 mb-0">Copyright © <script>document.write(/\d{4}/.exec(Date())[0])</script> PT Mid Solusi Nusantara.</p>


### PR DESCRIPTION
Preview screenshot
<img width="462" alt="Screen Shot 2022-01-21 at 17 34 47" src="https://user-images.githubusercontent.com/6992528/150512753-41fa105e-c6a0-49a9-badf-915466df916f.png">

`footer_content` key is deprecated based on the docs
https://pmarsceill.github.io/just-the-docs/docs/configuration/#footer-content
